### PR TITLE
Add test files for MPAS in E3SM's configuration

### DIFF
--- a/config/e3sm/config_archive.xml
+++ b/config/e3sm/config_archive.xml
@@ -10,15 +10,18 @@
       <rpointer_file>rpointer.atm$NINST_STRING</rpointer_file>
       <rpointer_content>$CASE.cam$NINST_STRING.r.$DATENAME.nc </rpointer_content>
     </rpointer>
-  </comp_archive_spec>
-
-  <comp_archive_spec compname="datm" compclass="atm">
-    <rest_file_extension>r</rest_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.atm$NINST_STRING</rpointer_file>
-      <rpointer_content >$CASE.datm$NINST_STRING.r.$DATENAME.nc,$CASE.datm$NINST_STRING.rs1.$DATENAME.bin</rpointer_content>
-    </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">rpointer.atm</tfile>
+      <tfile disposition="copy">rpointer.atm_9999</tfile>
+      <tfile disposition="copy">casename.cam.r.1976-01-01-00000.nc</tfile>
+      <tfile disposition="copy">casename.cam.rh4.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.cam.h0.1976-01-01-00000.nc</tfile>
+      <tfile disposition="ignore">casename.cam.h0.1976-01-01-00000.nc.base</tfile>
+      <tfile disposition="move">casename.cam_0002.e.postassim.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.cam_0002.e.preassim.1976-01-01-00000.nc</tfile>
+      <tfile disposition="copy">casename.cam.i.1976-01-01-00000.nc</tfile>
+      <tfile disposition="ignore">anothercasename.cam.i.1976-01-01-00000.nc</tfile>
+    </test_file_names>
   </comp_archive_spec>
 
   <comp_archive_spec compname="clm" compclass="lnd">
@@ -30,15 +33,17 @@
       <rpointer_file>rpointer.lnd$NINST_STRING</rpointer_file>
       <rpointer_content>./$CASE.clm2$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
-  </comp_archive_spec>
-
-  <comp_archive_spec compname="dlnd" compclass="lnd">
-    <rest_file_extension>r</rest_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.lnd$NINST_STRING</rpointer_file>
-      <rpointer_content >$CASE.dlnd$NINST_STRING.r.$DATENAME.nc,$CASE.dlnd$NINST_STRING.rs1.$DATENAME.bin</rpointer_content>
-    </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">rpointer.lnd</tfile>
+      <tfile disposition="copy">rpointer.lnd_9999</tfile>
+      <tfile disposition="copy">casename.clm2.r.1976-01-01-00000.nc</tfile>
+      <tfile disposition="copy">casename.clm2.rh4.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.clm2.h0.1976-01-01-00000.nc</tfile>
+      <tfile disposition="ignore">casename.clm2.h0.1976-01-01-00000.nc.base</tfile>
+      <tfile disposition="move">casename.clm2_0002.e.postassim.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.clm2_0002.e.preassim.1976-01-01-00000.nc</tfile>
+      <tfile disposition="ignore">anothercasename.clm2.i.1976-01-01-00000.nc</tfile>
+    </test_file_names>
   </comp_archive_spec>
 
   <comp_archive_spec compname="mosart" compclass="rof">
@@ -52,15 +57,6 @@
     </rpointer>
   </comp_archive_spec>
 
-  <comp_archive_spec compname="drof" compclass="rof">
-    <rest_file_extension>r</rest_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>
-      <rpointer_content>$CASE.drof$NINST_STRING.r.$DATENAME.nc,$CASE.drof$NINST_STRING.rs1.$DATENAME.bin</rpointer_content>
-    </rpointer>
-  </comp_archive_spec>
-
   <comp_archive_spec compname="cice" compclass="ice">
     <rest_file_extension>[ri]</rest_file_extension>
     <hist_file_extension>h\d*</hist_file_extension>
@@ -69,6 +65,11 @@
       <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
       <rpointer_content>./$CASE.cice$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">rpointer.ice</tfile>
+      <tfile disposition="copy">casename.cice.r.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.cice.h.1976-01-01-00000.nc</tfile>
+    </test_file_names>
   </comp_archive_spec>
 
   <comp_archive_spec compname="mpascice" compclass="ice">
@@ -79,15 +80,13 @@
       <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
       <rpointer_content>$MPAS_DATENAME</rpointer_content>
     </rpointer>
-  </comp_archive_spec>
-
-  <comp_archive_spec compname="dice" compclass="ice">
-    <rest_file_extension>r</rest_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
-      <rpointer_content>$CASE.dice$NINST_STRING.r.$DATENAME.nc,$CASE.dice$NINST_STRING.rs1.$DATENAME.bin</rpointer_content>
-    </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">rpointer.ice</tfile>
+      <tfile disposition="copy">mpascice.rst.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">mpascice.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">mpascice.hist.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">mpascice.hist.am.regionalStatistics.0001.01.nc</tfile>
+    </test_file_names>
   </comp_archive_spec>
 
   <comp_archive_spec compname="pop" compclass="ocn">
@@ -102,6 +101,17 @@
       <rpointer_file>rpointer.ocn$NINST_STRING.ovf</rpointer_file>
       <rpointer_content>./$CASE.pop$NINST_STRING.ro.$DATENAME</rpointer_content>
     </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">rpointer.pop</tfile>
+      <tfile disposition="copy">casename.pop_0001.r.1976-01-01-00000.nc</tfile>
+      <tfile disposition="copy">casename.pop.r.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.pop.h.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.pop.h.1975-02-01-00000.nc</tfile>
+      <tfile disposition="move">casename.pop.h0.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.pop.dd.1976-01-01-00000.nc</tfile>
+      <tfile disposition="ignore">casename.pop.r.1975-01-01-00000.nc</tfile>
+      <tfile disposition="ignore">anothercasename.pop.r.1976-01-01-00000.nc</tfile>
+    </test_file_names>
   </comp_archive_spec>
 
   <comp_archive_spec compname="mpaso" compclass="ocn">
@@ -112,15 +122,13 @@
       <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>
       <rpointer_content>$MPAS_DATENAME</rpointer_content>
     </rpointer>
-  </comp_archive_spec>
-
-  <comp_archive_spec compname="docn" compclass="ocn">
-    <rest_file_extension>r</rest_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>
-      <rpointer_content>$CASE.docn$NINST_STRING.r.$DATENAME.nc,$CASE.docn$NINST_STRING.rs1.$DATENAME.bin</rpointer_content>
-    </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">rpointer.ocn</tfile>
+      <tfile disposition="copy">mpaso.rst.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">mpaso.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">mpaso.hist.am.globalStats.1976-01-01.nc</tfile>
+      <tfile disposition="move">mpaso.hist.am.highFrequencyOutput.1976-01-01_00.00.00.nc</tfile>
+    </test_file_names>
   </comp_archive_spec>
 
   <comp_archive_spec compname="cism" compclass="glc">
@@ -132,6 +140,21 @@
       <rpointer_file>rpointer.glc$NINST_STRING</rpointer_file>
       <rpointer_content>./$CASE.cism$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
+    <test_file_names>
+      <!-- Should copy rpointer file(s) -->
+      <tfile disposition="copy">rpointer.glc</tfile>
+      <tfile disposition="copy">rpointer.glc_9999</tfile>
+      <!-- Should only copy last restart file -->
+      <tfile disposition="ignore">casename.cism.r.1975-01-01-00000.nc</tfile>
+      <tfile disposition="copy">casename.cism.r.1976-01-01-00000.nc</tfile>
+      <!-- Should copy all history files -->
+      <tfile disposition="move">casename.cism.initial_hist.0001-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.cism.h.1975-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.cism.h.1976-01-01-00000.nc</tfile>
+      <!-- Should ignore files created by test suite, files from other cases, etc. -->
+      <tfile disposition="ignore">casename.cism.h.1976-01-01-00000.nc.base</tfile>
+      <tfile disposition="ignore">anothercasename.cism.r.1976-01-01-00000.nc</tfile>
+    </test_file_names>
   </comp_archive_spec>
 
   <comp_archive_spec compname="mpasli" compclass="glc">
@@ -142,6 +165,13 @@
       <rpointer_file>rpointer.glc$NINST_STRING</rpointer_file>
       <rpointer_content>./mpasli$NINST_STRING.rst.$MPAS_DATENAME.nc</rpointer_content>
     </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">rpointer.glc</tfile>
+      <tfile disposition="copy">mpasli.rst.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">mpasli.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
+      <tfile disposition="move">mpasli.hist.am.globalStats.1976-01-01.nc</tfile>
+      <tfile disposition="move">mpasli.hist.am.highFrequencyOutput.1976-01-01_00.00.00.nc</tfile>
+    </test_file_names>
   </comp_archive_spec>
 
   <comp_archive_spec compname="ww3" compclass="wav">
@@ -154,15 +184,6 @@
     </rpointer>
   </comp_archive_spec>
 
-  <comp_archive_spec compname="dwav" compclass="wav">
-    <rest_file_extension>r</rest_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.wav$NINST_STRING</rpointer_file>
-      <rpointer_content >$CASE.dwav$NINST_STRING.r.$DATENAME.nc,$CASE.dwav$NINST_STRING.rs1.$DATENAME.bin</rpointer_content>
-    </rpointer>
-  </comp_archive_spec>
-
   <comp_archive_spec compclass="esp" compname="dart">
     <rest_file_extension>e\.\w+inf\w+</rest_file_extension>
     <hist_file_extension>[ei]</hist_file_extension>
@@ -171,6 +192,9 @@
       <rpointer_file>rpointer.unset</rpointer_file>
       <rpointer_content>unset</rpointer_content>
     </rpointer>
+    <test_file_names>
+      <tfile disposition="move">casename.dart.e.pop_preassim_priorinf_mean.1976-01-01-00000.nc</tfile>
+    </test_file_names>
   </comp_archive_spec>
 
 </components>


### PR DESCRIPTION
Also port over tests from the cesm configuration, and remove duplicate data components from E3SM's configuration.
This doesn't quite pass the st_archive test, reporting that it failed to move the `casename.cam.h0.*` file, though that may be my branch being out of date.